### PR TITLE
README x Geyser

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,10 @@ How to use IPv6?:
 - To use IPv6 in backend address, you need to use a instance with IPv6 connectivity. The hostname parser currently doesn't support direct IPv6, but you can use a DNS name.
 
 How to use with Geyser?
-- Currently you need to use GeyserConnect
+- Currently you need to set all the parameters in Geyser's `address` field  
+  e.g.:
+  ```yml
+  remote:
+    # The IP address of the remote (Java Edition) server
+    address: 2b2t.org._v1_12_2.viaaas.localhost
+  ```

--- a/README.md
+++ b/README.md
@@ -85,4 +85,5 @@ How to use with Geyser?
     # The IP address of the remote (Java Edition) server
     address: 2b2t.org._v1_12_2.viaaas.localhost
   ```
-- Remember to use BedrockConnect if you are on a console
+- If you are using a public GeyserConnect instance: connect to a publicly available VIAaaS instance ```mc.example.com.viaaas.example.net```,
+ replace ```viaaas.example.net``` with the VIAaaS address. Set as a Java Edition server.

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ How to use with Geyser?
     # The IP address of the remote (Java Edition) server
     address: 2b2t.org._v1_12_2.viaaas.localhost
   ```
-- Remember to use GeyserConnect if you are on a console
+- Remember to use BedrockConnect if you are on a console

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ How to use IPv6?:
 - To use IPv6 in backend address, you need to use a instance with IPv6 connectivity. The hostname parser currently doesn't support direct IPv6, but you can use a DNS name.
 
 How to use with Geyser?
-- Currently you need to set all the parameters in Geyser's `address` field  
-  e.g.:
+- Currently you need to set the parameters (at least the hostname) in Geyser's `address` field:
   ```yml
   remote:
     # The IP address of the remote (Java Edition) server

--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ How to use with Geyser?
     # The IP address of the remote (Java Edition) server
     address: 2b2t.org._v1_12_2.viaaas.localhost
   ```
+- Remember to use GeyserConnect if you are on a console


### PR DESCRIPTION
GeyserConnect is neither here nor there wrt VIAaaS. It's only necessary for *console* (but not phone, W10, or Amazon) users, anyway.

This PR updates the readme to contain more correct and helpful information.