### PR TITLE
Added Forge client to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ Web login:
   is the same)
 - Approve the login in the webpage
 
-Fabric client:
+Fabric/Forge client:
 
-- Install [OpenAuthMod](https://github.com/RaphiMC/OpenAuthMod) in your Fabric client.
+- Install [OpenAuthMod](https://github.com/RaphiMC/OpenAuthMod) in your Fabric or Forge client.
 - Join the server: ```mc.example.net.via.localhost```
 - Approve the login
 


### PR DESCRIPTION
OpenAuthMod now fully supports Forge clients. It uses the same protocol as the Fabric version for that of course.