### PR TITLE
Move to temurin JDK.

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 jdk:
   - openjdk17
 before_install:
-   - sdk install java 17.0.1-open
-   - sdk use java 17.0.1-open
+   - sdk install java 17.0.5+8-tem
+   - sdk use java 17.0.5+8-tem

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 jdk:
-  - openjdk17
+  - temurinjdk17
 before_install:
    - sdk install java 17.0.5+8-tem
    - sdk use java 17.0.5+8-tem


### PR DESCRIPTION
Ensures we have latest temurin JDK 17 instead of an outdated version of JDK 17 from oracle.