### PR TITLE
Update to support 1.20(.1)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,14 +60,14 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
 
-    val vvVer = "4.7.0-SNAPSHOT"
-    val vbVer = "4.7.0-SNAPSHOT"
+    val vvVer = "4.7.1-SNAPSHOT"
+    val vbVer = "4.7.1-SNAPSHOT"
     val vrVer = "4937bab"
     implementation("com.viaversion:viaversion:$vvVer") { isTransitive = false }
     implementation("com.viaversion:viabackwards:$vbVer") { isTransitive = false }
     implementation("com.github.ViaVersion.ViaRewind:viarewind-all:$vrVer") { isTransitive = false }
-    implementation("net.raphimc:ViaAprilFools:2.0.7-SNAPSHOT")
-    implementation("net.raphimc:ViaLegacy:2.2.17-SNAPSHOT")
+    implementation("net.raphimc:ViaAprilFools:2.0.8-SNAPSHOT")
+    implementation("net.raphimc:ViaLegacy:2.2.18-SNAPSHOT")
 
     val nettyVer = "4.1.91.Final"
     implementation("io.netty:netty-handler-proxy:$nettyVer")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,9 +60,9 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
 
-    val vvVer = "4.7.0-1.20-pre6-SNAPSHOT"
-    val vbVer = "4.7.0-1.20-pre5-SNAPSHOT"
-    val vrVer = "5f7fdc5"
+    val vvVer = "4.7.0-SNAPSHOT"
+    val vbVer = "4.7.0-SNAPSHOT"
+    val vrVer = "4937bab"
     implementation("com.viaversion:viaversion:$vvVer") { isTransitive = false }
     implementation("com.viaversion:viabackwards:$vbVer") { isTransitive = false }
     implementation("com.github.ViaVersion.ViaRewind:viarewind-all:$vrVer") { isTransitive = false }

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -125,7 +125,7 @@ frame-src 'self' https://login.microsoftonline.com/ https://login.live.com/"
                     </div>
                     <datalist id="backend_version_list">
                         <option>AUTO</option>
-                        <option>1.20</option>
+                        <option value="1.20.1">1.20(.1)</option>
                         <option>1.19.4</option>
                         <option>1.19.3</option>
                         <option value="1.19.2">1.19.1/2</option>

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -125,6 +125,7 @@ frame-src 'self' https://login.microsoftonline.com/ https://login.live.com/"
                     </div>
                     <datalist id="backend_version_list">
                         <option>AUTO</option>
+                        <option>1.20</option>
                         <option>1.19.4</option>
                         <option>1.19.3</option>
                         <option value="1.19.2">1.19.1/2</option>


### PR DESCRIPTION
Was getting "Incompatible Client" errors when trying to connect to a 1.20(.1) server, was fixed by updating the included ViaVersion
Also added an option in the web UI to specify connecting to a 1.20(.1) server, and also updated Via* things that I saw had updates