### PR TITLE
Removed MovementTransmitterProvider use() call

### DIFF
--- a/src/main/java/com/viaversion/aas/platform/AspirinLoader.java
+++ b/src/main/java/com/viaversion/aas/platform/AspirinLoader.java
@@ -8,15 +8,12 @@ import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.platform.ViaPlatformLoader;
 import com.viaversion.viaversion.api.protocol.version.VersionProvider;
 import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.CompressionProvider;
-import com.viaversion.viaversion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
-import com.viaversion.viaversion.velocity.providers.VelocityMovementTransmitter;
 import net.raphimc.vialegacy.protocols.release.protocol1_7_2_5to1_6_4.providers.EncryptionProvider;
 import net.raphimc.vialegacy.protocols.release.protocol1_8to1_7_6_10.providers.GameProfileFetcher;
 
 public class AspirinLoader implements ViaPlatformLoader {
 	@Override
 	public void load() {
-		Via.getManager().getProviders().use(MovementTransmitterProvider.class, new VelocityMovementTransmitter());
 		Via.getManager().getProviders().use(VersionProvider.class, new AspirinVersionProvider());
 		Via.getManager().getProviders().use(CompressionProvider.class, new AspirinCompressionProvider());
 


### PR DESCRIPTION
This PR implements the API Changes from https://github.com/ViaVersion/ViaVersion/commit/a817746edc971cc3d552e2ddb0591392f7241215