### PR TITLE
update viaversion deps for 1.21+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,14 +60,14 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
 
-    val vvVer = "5.0.2-SNAPSHOT"
-    val vbVer = "5.0.2-SNAPSHOT"
-    val vrVer = "4.0.2-SNAPSHOT"
+    val vvVer = "5.0.4-SNAPSHOT"
+    val vbVer = "5.0.4-SNAPSHOT"
+    val vrVer = "4.0.3-SNAPSHOT"
     implementation("com.viaversion:viaversion-common:$vvVer") { isTransitive = false }
     implementation("com.viaversion:viabackwards-common:$vbVer") { isTransitive = false }
     implementation("com.viaversion:viarewind-common:$vrVer") { isTransitive = false }
     implementation("net.raphimc:ViaAprilFools:3.0.1-SNAPSHOT")
-    implementation("net.raphimc:ViaLegacy:3.0.2-SNAPSHOT")
+    implementation("net.raphimc:ViaLegacy:3.0.3-SNAPSHOT")
 
     val nettyVer = "4.1.111.Final"
     implementation("io.netty:netty-handler-proxy:$nettyVer")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,14 +60,14 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
 
-    val vvVer = "5.0.4-SNAPSHOT"
-    val vbVer = "5.0.4-SNAPSHOT"
-    val vrVer = "4.0.3-SNAPSHOT"
+    val vvVer = "5.1.2-SNAPSHOT"
+    val vbVer = "5.1.2-SNAPSHOT"
+    val vrVer = "4.0.4-SNAPSHOT"
     implementation("com.viaversion:viaversion-common:$vvVer") { isTransitive = false }
     implementation("com.viaversion:viabackwards-common:$vbVer") { isTransitive = false }
     implementation("com.viaversion:viarewind-common:$vrVer") { isTransitive = false }
     implementation("net.raphimc:ViaAprilFools:3.0.1-SNAPSHOT")
-    implementation("net.raphimc:ViaLegacy:3.0.3-SNAPSHOT")
+    implementation("net.raphimc:ViaLegacy:3.0.6-SNAPSHOT")
 
     val nettyVer = "4.1.111.Final"
     implementation("io.netty:netty-handler-proxy:$nettyVer")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,10 +63,11 @@ dependencies {
     val vvVer = "5.1.2-SNAPSHOT"
     val vbVer = "5.1.2-SNAPSHOT"
     val vrVer = "4.0.4-SNAPSHOT"
+    val vafVer = "3.0.5-SNAPSHOT"
     implementation("com.viaversion:viaversion-common:$vvVer") { isTransitive = false }
     implementation("com.viaversion:viabackwards-common:$vbVer") { isTransitive = false }
     implementation("com.viaversion:viarewind-common:$vrVer") { isTransitive = false }
-    implementation("net.raphimc:ViaAprilFools:3.0.1-SNAPSHOT")
+    implementation("net.raphimc:viaaprilfools-common:$vafVer") { isTransitive = false }
     implementation("net.raphimc:ViaLegacy:3.0.6-SNAPSHOT")
 
     val nettyVer = "4.1.111.Final"

--- a/src/main/kotlin/com/viaversion/aas/handler/BackEndInit.kt
+++ b/src/main/kotlin/com/viaversion/aas/handler/BackEndInit.kt
@@ -8,7 +8,6 @@ import io.netty.channel.Channel
 import io.netty.channel.ChannelInitializer
 import io.netty.handler.timeout.ReadTimeoutHandler
 import net.raphimc.vialegacy.api.LegacyProtocolVersion
-import net.raphimc.vialegacy.api.protocol.PreNettyBaseProtocol
 import net.raphimc.vialegacy.netty.PreNettyLengthCodec
 import java.net.InetSocketAddress
 import java.net.URI
@@ -21,10 +20,6 @@ class BackEndInit(private val connectionData: ConnectionData, private val proxyU
         val pipeline = ProtocolPipelineImpl(user)
         val version = connectionData.backServerVer!!
         val isLegacy = version.olderThanOrEqualTo(LegacyProtocolVersion.r1_6_4)
-
-        if (isLegacy) {
-            pipeline.add(PreNettyBaseProtocol.INSTANCE)
-        }
 
         ch.pipeline()
             .also { addProxyHandler(it, proxyUri, proxyAddress) }

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -122,6 +122,7 @@ frame-src 'self' https://login.microsoftonline.com/ https://login.live.com/"
                     </div>
                     <datalist id="backend_version_list">
                         <option>AUTO</option>
+                        <option value="1.21.3">1.21.2/3</option>
                         <option value="1.21.1">1.21(.1)</option>
                         <option value="1.20.5">1.20.5/6</option>
                         <option value="1.20.4">1.20.3/4</option>

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -122,6 +122,7 @@ frame-src 'self' https://login.microsoftonline.com/ https://login.live.com/"
                     </div>
                     <datalist id="backend_version_list">
                         <option>AUTO</option>
+                        <option value="1.21.1">1.21(.1)</option>
                         <option value="1.20.5">1.20.5/6</option>
                         <option value="1.20.4">1.20.3/4</option>
                         <option>1.20.2</option>


### PR DESCRIPTION
- updated via* dependencies to their latest versions as of today and added 1.21+ options to the web page
- removed `PreNettyBaseProtocol` lines in [src/main/kotlin/com/viaversion/aas/handler/BackEndInit.kt](https://github.com/ViaVersion/VIAaaS/compare/master...RoblKyogre:VIAaaS:master?expand=1#diff-c655c1cf4613134591a85451f5bfa8cb241725f1682a22398b4e9bbed4d82dca), as the ViaLegacy API seems to no longer require it as of https://github.com/ViaVersion/ViaLegacy/commit/7f1cb82cf6ef05c335510c4b34ffc5a6ef82bf83
- changed ViaAprilFools dependency to be in-line with the other via* dependencies (viaversion, viabackwards, viarewind), as it now gets updated under `viaaprilfools-common`